### PR TITLE
Added paths config to buildRequire()

### DIFF
--- a/stache.js
+++ b/stache.js
@@ -29,6 +29,7 @@ define([
     var buildRequire = require.config({
         context: '__build',
         baseUrl: require.s.contexts._.config.baseUrl,
+        paths: require.s.contexts._.config.paths,
         map: {
             '*': {
                 'can/util/jquery' : 'can/util/domless'


### PR DESCRIPTION
Otherwise, building with requirejs fails, if CanJS is included via bower (`../bower_components/`):

```
[Error: Tried loading "can/view/intermediate_and_imports" at /cdn/js/can/view/intermediate_and_imports.js
then tried node's require("can/view/intermediate_and_imports") and it failed with error: 
Error: Cannot find module 'can/view/intermediate_and_imports']
originalError: { [Error: Cannot find module 'can/view/intermediate_and_imports'] code: 'MODULE_NOT_FOUND' },
moduleName: 'can/view/intermediate_and_imports',
requireModules: [ 'can/view/intermediate_and_imports' ] }
```
